### PR TITLE
Background sub

### DIFF
--- a/src/main/java/io/resurface/BaseLogger.java
+++ b/src/main/java/io/resurface/BaseLogger.java
@@ -213,7 +213,11 @@ public class BaseLogger<T extends BaseLogger> {
         }
     }
 
-    public void handleSubmit(String msg) {
+    /**
+     * Adds message to queue for dispatcher thread.
+     * @param msg String with tuple-JSON formatted message. More info: https://resurface.io/docs#json-format
+     */
+    public void submit(String msg) {
         try {
             this.msg_queue.put(msg);
         } catch (InterruptedException ex) {
@@ -224,7 +228,7 @@ public class BaseLogger<T extends BaseLogger> {
     /**
      * Submits JSON message to intended destination.
      */
-    public void submit(String msg) {
+    public void dispatch(String msg) {
         if (msg == null || this.skip_submission || !isEnabled()) {
             // do nothing
         } else if (queue != null) {

--- a/src/main/java/io/resurface/BaseLogger.java
+++ b/src/main/java/io/resurface/BaseLogger.java
@@ -240,7 +240,7 @@ public class BaseLogger<T extends BaseLogger> {
                 url_connection.setConnectTimeout(5000);
                 url_connection.setReadTimeout(1000);
                 url_connection.setRequestMethod("POST");
-                url_connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                url_connection.setRequestProperty("Content-Type", "application/ndjson; charset=UTF-8");
                 url_connection.setRequestProperty("User-Agent", "Resurface/" + version + " (" + agent + ")");
                 url_connection.setDoOutput(true);
                 if (!this.skip_compression) url_connection.setRequestProperty("Content-Encoding", "deflated");

--- a/src/main/java/io/resurface/BaseLogger.java
+++ b/src/main/java/io/resurface/BaseLogger.java
@@ -310,8 +310,16 @@ public class BaseLogger<T extends BaseLogger> {
      * Initializes message queue and starts dispatcher thread.
      */
     public void init_dispatcher() {
+        this.init_dispatcher(50 * 1024);
+    }
+
+    /**
+     * Initializes message queue and starts dispatcher thread.
+     * @param batchSize threshold for the NDJSON batch
+     */
+    public void init_dispatcher(int batchSize) {
         setMessageQueue();
-        worker = new Thread(new Dispatcher(this));
+        worker = new Thread(new Dispatcher(this, batchSize));
         worker.start();
     }
 

--- a/src/main/java/io/resurface/BaseLogger.java
+++ b/src/main/java/io/resurface/BaseLogger.java
@@ -213,6 +213,14 @@ public class BaseLogger<T extends BaseLogger> {
         }
     }
 
+    public void handleSubmit(String msg) {
+        try {
+            this.msg_queue.put(msg);
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+        }
+    }
+
     /**
      * Submits JSON message to intended destination.
      */

--- a/src/main/java/io/resurface/BaseServletRequestImpl.java
+++ b/src/main/java/io/resurface/BaseServletRequestImpl.java
@@ -272,12 +272,12 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     }
 
     @Override
-    public String changeSessionId() { throw new UnsupportedOperationException(); }
-
-    @Override
     public HttpSession getSession(boolean create) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String changeSessionId() { throw new UnsupportedOperationException(); }
 
     @Override
     public Principal getUserPrincipal() {

--- a/src/main/java/io/resurface/BaseServletRequestImpl.java
+++ b/src/main/java/io/resurface/BaseServletRequestImpl.java
@@ -54,6 +54,11 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     }
 
     @Override
+    public long getContentLengthLong() {
+        return 0;
+    }
+
+    @Override
     public String getContentType() {
         throw new UnsupportedOperationException();
     }
@@ -159,6 +164,11 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     }
 
     @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
     public Collection<Part> getParts() {
         throw new UnsupportedOperationException();
     }
@@ -261,6 +271,11 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     @Override
     public HttpSession getSession() {
         return getSession(true);
+    }
+
+    @Override
+    public String changeSessionId() {
+        return null;
     }
 
     @Override

--- a/src/main/java/io/resurface/BaseServletRequestImpl.java
+++ b/src/main/java/io/resurface/BaseServletRequestImpl.java
@@ -54,9 +54,7 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     }
 
     @Override
-    public long getContentLengthLong() {
-        return 0;
-    }
+    public long getContentLengthLong() { throw new UnsupportedOperationException(); }
 
     @Override
     public String getContentType() {
@@ -165,7 +163,7 @@ public class BaseServletRequestImpl implements HttpServletRequest {
 
     @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -274,9 +272,7 @@ public class BaseServletRequestImpl implements HttpServletRequest {
     }
 
     @Override
-    public String changeSessionId() {
-        return null;
-    }
+    public String changeSessionId() { throw new UnsupportedOperationException(); }
 
     @Override
     public HttpSession getSession(boolean create) {

--- a/src/main/java/io/resurface/BaseServletResponseImpl.java
+++ b/src/main/java/io/resurface/BaseServletResponseImpl.java
@@ -161,9 +161,7 @@ public class BaseServletResponseImpl implements HttpServletResponse {
     }
 
     @Override
-    public void setContentLengthLong(long l) {
-
-    }
+    public void setContentLengthLong(long l) { throw new UnsupportedOperationException(); }
 
     @Override
     public void setContentType(String contentType) {

--- a/src/main/java/io/resurface/BaseServletResponseImpl.java
+++ b/src/main/java/io/resurface/BaseServletResponseImpl.java
@@ -161,6 +161,11 @@ public class BaseServletResponseImpl implements HttpServletResponse {
     }
 
     @Override
+    public void setContentLengthLong(long l) {
+
+    }
+
+    @Override
     public void setContentType(String contentType) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -3,26 +3,25 @@ package io.resurface;
 public class Dispatcher extends Thread{
 
     protected Dispatcher(BaseLogger logger) {
-        this(logger, 100);
+        this(logger, 50 * 1024);
     }
 
     protected Dispatcher(BaseLogger logger, int threshold) {
         this.logger = logger;
-        this.thresh = threshold * 2;
-        this.buffer = new StringBuilder(this.thresh);
+        thresh = threshold;
+        buffer = new StringBuilder(thresh);
     }
 
     public void run() {
         try {
             while (true) {
 //                String msg = (String) this.logger.msg_queue.take();
-                if ((this.logger.msg_queue.peek() == null && this.buffer.length() != 0) || this.buffer.length() == thresh) {
-                    String msg = this.buffer.toString();
-                    this.buffer = new StringBuilder();
-                    this.logger.dispatch(msg);
+                if ((logger.msg_queue.peek() == null && buffer.length() != 0) || buffer.length() == thresh) {
+                    String msg = buffer.toString();
+                    buffer = new StringBuilder();
+                    logger.dispatch(msg);
                 }
-                this.buffer.append(this.logger.msg_queue.take());
-                this.buffer.append("\n");
+                buffer.append(logger.msg_queue.take()).append("\n");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -3,14 +3,26 @@ package io.resurface;
 public class Dispatcher extends Thread{
 
     protected Dispatcher(BaseLogger logger) {
+        this(logger, 100);
+    }
+
+    protected Dispatcher(BaseLogger logger, int threshold) {
         this.logger = logger;
+        this.thresh = threshold * 2;
+        this.buffer = new StringBuilder(this.thresh);
     }
 
     public void run() {
         try {
             while (true) {
-                String msg = (String) this.logger.msg_queue.take();
-                this.logger.dispatch(msg);
+//                String msg = (String) this.logger.msg_queue.take();
+                this.buffer.append(this.logger.msg_queue.take());
+                this.buffer.append("\n");
+                if (this.buffer.length() != thresh) {
+                    String msg = this.buffer.toString();
+                    this.buffer = new StringBuilder();
+                    this.logger.dispatch(msg);
+                }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -18,4 +30,6 @@ public class Dispatcher extends Thread{
     }
 
     private final BaseLogger logger;
+    private StringBuilder buffer;
+    private final int thresh;
 }

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -16,13 +16,13 @@ public class Dispatcher extends Thread{
         try {
             while (true) {
 //                String msg = (String) this.logger.msg_queue.take();
-                this.buffer.append(this.logger.msg_queue.take());
-                this.buffer.append("\n");
-                if (this.buffer.length() == thresh) {
+                if ((this.logger.msg_queue.peek() == null && this.buffer.length() != 0) || this.buffer.length() == thresh) {
                     String msg = this.buffer.toString();
                     this.buffer = new StringBuilder();
                     this.logger.dispatch(msg);
                 }
+                this.buffer.append(this.logger.msg_queue.take());
+                this.buffer.append("\n");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -1,5 +1,7 @@
 package io.resurface;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class Dispatcher implements Runnable {
 
     /**
@@ -36,6 +38,8 @@ public class Dispatcher implements Runnable {
      */
     private void flushAndDispatch() {
         if (buffer.length() != 0) {
+            if (buffer.length() >= batchingThreshold) full_buffer_count.incrementAndGet();
+            if (logger.msg_queue.peek() == null) empty_queue_count.incrementAndGet();
             String msg = buffer.toString();
             buffer = new StringBuilder();
             logger.dispatch(msg);
@@ -45,4 +49,6 @@ public class Dispatcher implements Runnable {
     private final BaseLogger logger;
     private StringBuilder buffer;
     private final int batchingThreshold;
+    private final AtomicInteger full_buffer_count = new AtomicInteger();
+    private final AtomicInteger empty_queue_count = new AtomicInteger();
 }

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -1,0 +1,21 @@
+package io.resurface;
+
+public class Dispatcher extends Thread{
+
+    protected Dispatcher(BaseLogger logger) {
+        this.logger = logger;
+    }
+
+    public void run() {
+        try {
+            while (true) {
+                String msg = (String) this.logger.msg_queue.take();
+                this.logger.submit(msg);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private final BaseLogger logger;
+}

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -3,14 +3,6 @@ package io.resurface;
 public class Dispatcher implements Runnable {
 
     /**
-     * Initialize dispatcher with default NDJSON buffer size (100 kiB).
-     * @param logger Resurface logger.
-     */
-    public Dispatcher(BaseLogger logger) {
-        this(logger, 50 * 1024);
-    }
-
-    /**
      * Initialize dispatcher using buffer size.
      * @param logger Resurface logger.
      * @param threshold NDJSON buffer max size - flushAndDispatch will be triggered after reaching this point.
@@ -48,18 +40,6 @@ public class Dispatcher implements Runnable {
             buffer = new StringBuilder();
             logger.dispatch(msg);
         }
-    }
-
-    public BaseLogger getLogger() {
-        return logger;
-    }
-
-    public StringBuilder getNDJSONBuffer() {
-        return buffer;
-    }
-
-    public int getBatchingThreshold() {
-        return batchingThreshold;
     }
 
     private final BaseLogger logger;

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -10,7 +10,7 @@ public class Dispatcher extends Thread{
         try {
             while (true) {
                 String msg = (String) this.logger.msg_queue.take();
-                this.logger.submit(msg);
+                this.logger.dispatch(msg);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/io/resurface/Dispatcher.java
+++ b/src/main/java/io/resurface/Dispatcher.java
@@ -18,7 +18,7 @@ public class Dispatcher extends Thread{
 //                String msg = (String) this.logger.msg_queue.take();
                 this.buffer.append(this.logger.msg_queue.take());
                 this.buffer.append("\n");
-                if (this.buffer.length() != thresh) {
+                if (this.buffer.length() == thresh) {
                     String msg = this.buffer.toString();
                     this.buffer = new StringBuilder();
                     this.logger.dispatch(msg);

--- a/src/main/java/io/resurface/HttpLogger.java
+++ b/src/main/java/io/resurface/HttpLogger.java
@@ -129,7 +129,7 @@ public class HttpLogger extends BaseLogger<HttpLogger> {
         details.add(new String[]{"host", this.host});
 
         // let's do this thing
-        submit(Json.stringify(details));
+        handleSubmit(Json.stringify(details));
     }
 
     protected HttpRules rules;

--- a/src/main/java/io/resurface/HttpLogger.java
+++ b/src/main/java/io/resurface/HttpLogger.java
@@ -129,7 +129,7 @@ public class HttpLogger extends BaseLogger<HttpLogger> {
         details.add(new String[]{"host", this.host});
 
         // let's do this thing
-        handleSubmit(Json.stringify(details));
+        submit(Json.stringify(details));
     }
 
     protected HttpRules rules;

--- a/src/main/java/io/resurface/HttpMessage.java
+++ b/src/main/java/io/resurface/HttpMessage.java
@@ -133,15 +133,11 @@ public class HttpMessage {
     }
 
     /**
-     * Returns complete request URL including query string.
+     * Returns complete request URL without query string.
      */
     private static String formatURL(HttpServletRequest request) {
         StringBuffer url = request.getRequestURL();
-        if (url != null) {
-            String queryString = request.getQueryString();
-            if (queryString != null) url.append('?').append(queryString);
-        }
-        return (url == null) ? null : url.toString();
+        return (url == null) ? null : url.toString().split("\\?")[0];
     }
 
 }

--- a/src/main/java/io/resurface/HttpServletResponseImpl.java
+++ b/src/main/java/io/resurface/HttpServletResponseImpl.java
@@ -17,12 +17,12 @@ public class HttpServletResponseImpl extends BaseServletResponseImpl {
         stream = new ServletOutputStream() {
             @Override
             public boolean isReady() {
-                return false;
+                throw new UnsupportedOperationException();
             }
 
             @Override
             public void setWriteListener(WriteListener writeListener) {
-
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/src/main/java/io/resurface/HttpServletResponseImpl.java
+++ b/src/main/java/io/resurface/HttpServletResponseImpl.java
@@ -3,6 +3,7 @@
 package io.resurface;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.*;
@@ -14,6 +15,16 @@ public class HttpServletResponseImpl extends BaseServletResponseImpl {
 
     public HttpServletResponseImpl() {
         stream = new ServletOutputStream() {
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener writeListener) {
+
+            }
+
             @Override
             public void write(int b) throws IOException {
                 // do nothing

--- a/src/main/java/io/resurface/LoggedInputStream.java
+++ b/src/main/java/io/resurface/LoggedInputStream.java
@@ -2,6 +2,7 @@
 
 package io.resurface;
 
+import javax.servlet.ReadListener;
 import java.io.*;
 
 /**
@@ -94,4 +95,18 @@ public class LoggedInputStream extends javax.servlet.ServletInputStream {
     private byte[] logged;
     private final ByteArrayInputStream stream;
 
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+
+    }
 }

--- a/src/main/java/io/resurface/LoggedInputStream.java
+++ b/src/main/java/io/resurface/LoggedInputStream.java
@@ -92,21 +92,21 @@ public class LoggedInputStream extends javax.servlet.ServletInputStream {
         return stream.read(b, off, len);
     }
 
-    private byte[] logged;
-    private final ByteArrayInputStream stream;
-
     @Override
     public boolean isFinished() {
-        return false;
+        return stream.available() == 0;
     }
 
     @Override
     public boolean isReady() {
-        return false;
+        return stream.available() != 0;
     }
 
     @Override
     public void setReadListener(ReadListener readListener) {
-
+        throw new UnsupportedOperationException();
     }
+
+    private byte[] logged;
+    private final ByteArrayInputStream stream;
 }

--- a/src/main/java/io/resurface/LoggedOutputStream.java
+++ b/src/main/java/io/resurface/LoggedOutputStream.java
@@ -28,6 +28,7 @@ public class LoggedOutputStream extends javax.servlet.ServletOutputStream {
         this.limit = limit;
         this.logged = new ByteArrayOutputStream();
         this.output = output;
+        this.isClosed = false;
     }
 
     /**
@@ -42,6 +43,8 @@ public class LoggedOutputStream extends javax.servlet.ServletOutputStream {
                 logged.close();
             } catch (IOException ioe) {
                 // do nothing
+            } finally {
+                isClosed = true;
             }
         }
     }
@@ -144,19 +147,20 @@ public class LoggedOutputStream extends javax.servlet.ServletOutputStream {
         }
     }
 
+    @Override
+    public boolean isReady() {
+        return !this.isClosed;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        throw new UnsupportedOperationException();
+    }
+
     private final int limit;
     private ByteArrayOutputStream logged;
     private int logged_bytes = 0;
     private final OutputStream output;
     private boolean overflowed = false;
-
-    @Override
-    public boolean isReady() {
-        return false;
-    }
-
-    @Override
-    public void setWriteListener(WriteListener writeListener) {
-
-    }
+    private boolean isClosed;
 }

--- a/src/main/java/io/resurface/LoggedOutputStream.java
+++ b/src/main/java/io/resurface/LoggedOutputStream.java
@@ -2,6 +2,7 @@
 
 package io.resurface;
 
+import javax.servlet.WriteListener;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -148,4 +149,14 @@ public class LoggedOutputStream extends javax.servlet.ServletOutputStream {
     private int logged_bytes = 0;
     private final OutputStream output;
     private boolean overflowed = false;
+
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+
+    }
 }

--- a/src/test/java/io/resurface/tests/Helper.java
+++ b/src/test/java/io/resurface/tests/Helper.java
@@ -156,7 +156,7 @@ public class Helper {
     }
 
     static boolean parseable(String msg) {
-        if (msg == null || !msg.startsWith("[") || !msg.endsWith("]")
+        if (msg == null || !msg.trim().startsWith("[") || !msg.trim().endsWith("]")
                 || msg.contains("[]") || (msg.contains(",,"))) return false;
         try {
             parser.fromJson(msg, Object.class);

--- a/src/test/java/io/resurface/tests/Helper.java
+++ b/src/test/java/io/resurface/tests/Helper.java
@@ -51,6 +51,8 @@ public class Helper {
     static final String[] MOCK_URLS_INVALID = {"", "noway3is5this1valid2", "ftp:\\www.noway3is5this1valid2.com/",
             "urn:ISSN:1535–3613"};
 
+    static final String MOCK_MESSAGE = "[[\"message\"], [123]]";
+
     static FilterChain mockCustomApp() {
         return (req, res) -> {
             HttpServletResponse response = (HttpServletResponse) res;

--- a/src/test/java/io/resurface/tests/HttpLoggerForServletsTest.java
+++ b/src/test/java/io/resurface/tests/HttpLoggerForServletsTest.java
@@ -25,7 +25,9 @@ public class HttpLoggerForServletsTest {
         List<String> queue = new ArrayList<>();
         HttpLoggerForServlets filter = new HttpLoggerForServlets(queue, "include standard");
         filter.init(null);
+        filter.getLogger().init_dispatcher();
         filter.doFilter(mockRequest(), mockResponse(), mockHtmlApp());
+        filter.getLogger().stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -47,7 +49,9 @@ public class HttpLoggerForServletsTest {
         List<String> queue = new ArrayList<>();
         HttpLoggerForServlets filter = new HttpLoggerForServlets(queue, "include standard");
         filter.init(null);
+        filter.getLogger().init_dispatcher();
         filter.doFilter(mockRequest(), mockResponse(), mockJsonApp());
+        filter.getLogger().stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -65,14 +69,16 @@ public class HttpLoggerForServletsTest {
         List<String> queue = new ArrayList<>();
         HttpLoggerForServlets filter = new HttpLoggerForServlets(queue, "include standard");
         filter.init(null);
+        filter.getLogger().init_dispatcher();
         filter.doFilter(mockRequestWithJson(), mockResponse(), mockJsonApp());
+        filter.getLogger().stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
         expect(msg).toContain("[\"request_header:content-type\",\"Application/JSON\"]");
         expect(msg).toContain("[\"request_method\",\"POST\"]");
         expect(msg).toContain("[\"request_param:message\",\"" + MOCK_JSON_ESCAPED + "\"]");
-        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + '?' + MOCK_QUERY_STRING + "\"]");
+        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + "\"]");
         expect(msg).toContain("[\"response_body\",\"" + MOCK_JSON_ESCAPED + "\"]");
         expect(msg).toContain("[\"response_code\",\"200\"]");
         expect(msg).toContain("[\"response_header:content-type\",\"application/json; charset=utf-8\"]");
@@ -83,7 +89,9 @@ public class HttpLoggerForServletsTest {
         List<String> queue = new ArrayList<>();
         HttpLoggerForServlets filter = new HttpLoggerForServlets(queue, "include standard");
         filter.init(null);
+        filter.getLogger().init_dispatcher();
         filter.doFilter(mockRequestWithJson2(), mockResponse(), mockHtmlApp());
+        filter.getLogger().stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -94,7 +102,7 @@ public class HttpLoggerForServletsTest {
         expect(msg).toContain("[\"request_param:abc\",\"123\"]");
         expect(msg).toContain("[\"request_param:abc\",\"234\"]");
         expect(msg).toContain("[\"request_param:message\",\"" + MOCK_JSON_ESCAPED + "\"]");
-        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + '?' + MOCK_QUERY_STRING + "\"]");
+        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + "\"]");
         expect(msg).toContain("[\"response_body\",\"" + MOCK_HTML + "\"]");
         expect(msg).toContain("[\"response_code\",\"200\"]");
         expect(msg).toContain("[\"response_header:a\",\"Z\"]");
@@ -106,6 +114,7 @@ public class HttpLoggerForServletsTest {
         List<String> queue = new ArrayList<>();
         HttpLoggerForServlets filter = new HttpLoggerForServlets(queue, "include standard");
         filter.init(null);
+        filter.getLogger().init_dispatcher();
         try {
             filter.doFilter(mockRequest(), mockResponse(), mockExceptionApp());
         } catch (UnsupportedEncodingException uee) {

--- a/src/test/java/io/resurface/tests/HttpLoggerRulesTest.java
+++ b/src/test/java/io/resurface/tests/HttpLoggerRulesTest.java
@@ -6,6 +6,7 @@ import io.resurface.HttpLogger;
 import io.resurface.HttpMessage;
 import io.resurface.HttpRules;
 import org.junit.Test;
+import org.junit.Assert;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
@@ -80,27 +81,35 @@ public class HttpLoggerRulesTest {
 
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "copy_session_field /.*/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:butterfly\",\"poison\"]")).toBeTrue();
         expect(queue.get(0).contains("[\"session_field:session_id\",\"asdf1234\"]")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field /session_id/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:butterfly\",")).toBeFalse();
         expect(queue.get(0).contains("[\"session_field:session_id\",\"asdf1234\"]")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field /blah/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field /butterfly/\ncopy_session_field /session_id/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:butterfly\",\"poison\"]")).toBeTrue();
         expect(queue.get(0).contains("[\"session_field:session_id\",\"asdf1234\"]")).toBeTrue();
@@ -114,27 +123,35 @@ public class HttpLoggerRulesTest {
 
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:.*! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:butterfly! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:butterfly\",")).toBeFalse();
         expect(queue.get(0).contains("[\"session_field:session_id\",\"asdf1234\"]")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:.*! remove_if !poi.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:butterfly\",")).toBeFalse();
         expect(queue.get(0).contains("[\"session_field:session_id\",\"asdf1234\"]")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:.*! remove_unless !sugar!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"session_field:")).toBeFalse();
     }
@@ -147,17 +164,23 @@ public class HttpLoggerRulesTest {
 
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:butterfly! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:butterfly! stop_if !poi.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "copy_session_field !.*!\n!session_field:butterfly! stop_unless !sugar!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, request, mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
     }
 
@@ -165,33 +188,43 @@ public class HttpLoggerRulesTest {
     public void usesRemoveRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!.*! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body|response_body! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_header:.*! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"request_header:")).toBeFalse();
@@ -199,7 +232,9 @@ public class HttpLoggerRulesTest {
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_header:abc! remove\n!response_body! remove");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"request_header:")).toBeTrue();
@@ -211,45 +246,59 @@ public class HttpLoggerRulesTest {
     public void usesRemoveIfRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! remove_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!.*! remove_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_if !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_if !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove_if !.*!\n!response_body! remove_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
@@ -259,45 +308,59 @@ public class HttpLoggerRulesTest {
     public void usesRemoveIfFoundRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! remove_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!.*! remove_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_if_found !World!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_if_found !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_if_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
@@ -307,45 +370,59 @@ public class HttpLoggerRulesTest {
     public void usesRemoveUnlessRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! remove_unless !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!.*! remove_unless !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove_unless !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove_unless !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_unless !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_unless !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove_unless !.*!\n!request_body! remove_unless !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
@@ -355,45 +432,59 @@ public class HttpLoggerRulesTest {
     public void usesRemoveUnlessFoundRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! remove_unless_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!.*! remove_unless_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! remove_unless_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! remove_unless_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_unless_found !World!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_unless_found !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeFalse();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body|request_body! remove_unless_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"request_body\",")).toBeTrue();
         expect(queue.get(0).contains("[\"response_body\",")).toBeTrue();
@@ -403,52 +494,68 @@ public class HttpLoggerRulesTest {
     public void usesReplaceRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_body! replace !blahblahblah!, !ZZZZZ!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("World")).toBeTrue();
         expect(queue.get(0).contains("ZZZZZ")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !World!, !Mundo!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello Mundo!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body|response_body! replace !^.*!, !ZZZZZ!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"request_body\",\"ZZZZZ\"],");
         expect(queue.get(0)).toContain("[\"response_body\",\"ZZZZZ\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! replace !^.*!, !QQ!\n!response_body! replace !^.*!, !SS!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"request_body\",\"QQ\"],");
         expect(queue.get(0)).toContain("[\"response_body\",\"SS\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !World!, !!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello !</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !.*!, !!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0).contains("[\"response_body\",")).toBeFalse();
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !World!, !Z!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML3, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>1 Z 2 Z Red Z Blue Z!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !World!, !Z!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML4, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>1 Z\\n2 Z\\nRed Z \\nBlue Z!\\n</html>\"],");
     }
@@ -457,31 +564,41 @@ public class HttpLoggerRulesTest {
     public void usesReplaceRulesWithComplexExpressionsTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "/response_body/ replace /[a-zA-Z0-9.!#$%&’*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)/, /x@y.com/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML.replace("World", "rob@resurface.io"), MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello x@y.com!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "/response_body/ replace /[0-9\\.\\-\\/]{9,}/, /xyxy/");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML.replace("World", "123-45-1343"), MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello xyxy!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !World!, !<b>$0</b>!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello <b>World</b>!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !(World)!, !<b>$1</b>!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>Hello <b>World</b>!</html>\"],");
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! replace !<input([^>]*)>([^<]*)</input>!, !<input$1></input>!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML5, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         expect(queue.get(0)).toContain("[\"response_body\",\"<html>\\n<input type=\\\"hidden\\\"></input>\\n<input class='foo' type=\\\"hidden\\\"></input>\\n</html>\"],");
     }
@@ -498,9 +615,11 @@ public class HttpLoggerRulesTest {
         }
 
         HttpLogger logger = new HttpLogger(queue, "sample 10");
+        logger.init_dispatcher();
         for (int i = 1; i <= 100; i++) {
             HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml());
         }
+        logger.stop_dispatcher();
         expect(queue.size()).toBeBetween(2, 20);
     }
 
@@ -528,27 +647,37 @@ public class HttpLoggerRulesTest {
     public void usesStopRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!.*! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), null, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!request_body! stop\n!response_body! stop");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), null, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
     }
 
@@ -556,22 +685,30 @@ public class HttpLoggerRulesTest {
     public void usesStopIfRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! stop_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
     }
 
@@ -579,27 +716,37 @@ public class HttpLoggerRulesTest {
     public void usesStopIfFoundRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! stop_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if_found !World!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if_found !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_if_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, MOCK_JSON);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
     }
 
@@ -607,22 +754,30 @@ public class HttpLoggerRulesTest {
     public void usesStopUnlessRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! stop_unless !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless !.*blahblahblah.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
     }
 
@@ -630,27 +785,37 @@ public class HttpLoggerRulesTest {
     public void usesStopUnlessFoundRulesTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "!response_header:blahblahblah! stop_unless_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless_found !.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless_found !World!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless_found !.*World.*!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
 
         queue = new ArrayList<>();
         logger = new HttpLogger(queue, "!response_body! stop_unless_found !blahblahblah!");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponseWithHtml(), MOCK_HTML, null);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(0);
     }
 

--- a/src/test/java/io/resurface/tests/HttpMessageTest.java
+++ b/src/test/java/io/resurface/tests/HttpMessageTest.java
@@ -49,7 +49,7 @@ public class HttpMessageTest {
         expect(msg).toContain("[\"request_header:content-type\",\"Application/JSON\"]");
         expect(msg).toContain("[\"request_method\",\"POST\"]");
         expect(msg).toContain("[\"request_param:message\",\"" + MOCK_JSON_ESCAPED + "\"]");
-        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + '?' + MOCK_QUERY_STRING + "\"]");
+        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + "\"]");
         expect(msg.contains("request_param:foo")).toBeFalse();
     }
 
@@ -69,7 +69,7 @@ public class HttpMessageTest {
         expect(msg).toContain("[\"request_param:abc\",\"123\"]");
         expect(msg).toContain("[\"request_param:abc\",\"234\"]");
         expect(msg).toContain("[\"request_param:message\",\"" + MOCK_JSON_ESCAPED + "\"]");
-        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + '?' + MOCK_QUERY_STRING + "\"]");
+        expect(msg).toContain("[\"request_url\",\"" + MOCK_URL + "\"]");
         expect(msg.contains("request_body")).toBeFalse();
         expect(msg.contains("request_param:foo")).toBeFalse();
     }

--- a/src/test/java/io/resurface/tests/HttpMessageTest.java
+++ b/src/test/java/io/resurface/tests/HttpMessageTest.java
@@ -23,7 +23,9 @@ public class HttpMessageTest {
     public void formatRequestTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequest(), mockResponse(), null, null, MOCK_NOW, 0);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -41,7 +43,9 @@ public class HttpMessageTest {
     public void formatRequestWithBodyTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson(), mockResponse(), null, MOCK_HTML);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -57,7 +61,9 @@ public class HttpMessageTest {
     public void formatRequestWithEmptyBodyTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequestWithJson2(), mockResponse(), null, "");
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -78,7 +84,9 @@ public class HttpMessageTest {
     public void formatRequestWithMissingDetailsTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, new HttpServletRequestImpl(), mockResponse(), null, null, MOCK_NOW, 0);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -94,7 +102,9 @@ public class HttpMessageTest {
     public void formatResponseTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequest(), mockResponse());
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -107,7 +117,9 @@ public class HttpMessageTest {
     public void formatResponseWithBodyTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequest(), mockResponseWithHtml(), MOCK_HTML2);
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -120,7 +132,9 @@ public class HttpMessageTest {
     public void formatResponseWithEmptyBodyTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequest(), mockResponseWithHtml(), "");
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();
@@ -133,7 +147,9 @@ public class HttpMessageTest {
     public void formatResponseWithMissingDetailsTest() {
         List<String> queue = new ArrayList<>();
         HttpLogger logger = new HttpLogger(queue, "include debug");
+        logger.init_dispatcher();
         HttpMessage.send(logger, mockRequest(), new HttpServletResponseImpl());
+        logger.stop_dispatcher();
         expect(queue.size()).toEqual(1);
         String msg = queue.get(0);
         expect(parseable(msg)).toBeTrue();

--- a/src/test/java/io/resurface/tests/ThroughputTest.java
+++ b/src/test/java/io/resurface/tests/ThroughputTest.java
@@ -1,0 +1,160 @@
+package io.resurface.tests;
+
+import io.resurface.BaseLogger;
+import io.resurface.Dispatcher;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.mscharhag.oleaster.matcher.Matchers.expect;
+import static io.resurface.tests.Helper.MOCK_AGENT;
+
+
+public class ThroughputTest {
+    @Test
+    public void timedArrayMessageQueueTest() {
+        for (int i = 1; i < 10000; i*=10) {
+            System.out.printf("ARRAY BLOCKING QUEUE (message count = %d)%n", i);
+            List<String> queue = new ArrayList<>();
+            BaseLogger logger = new BaseLogger(MOCK_AGENT, queue, true, 100);
+            timedMessageQueuePutTakeTest(logger, i, 1000);
+        }
+        System.out.println();
+    }
+
+    @Test
+    public void timedLinkedMessageQueueTest() throws InterruptedException{
+        for (int i = 1; i < 10000; i*=10) {
+            System.out.printf("LINKED BLOCKING QUEUE (message count = %d)%n", i);
+            List<String> queue = new ArrayList<>();
+            BaseLogger logger = new LinkedBaseLogger(queue, 100);
+            timedMessageQueuePutTakeTest(logger, i, 1000);
+        }
+        System.out.println();
+    }
+
+    private void timedMessageQueuePutTakeTest(BaseLogger logger, int messageCount, int iterations) {
+        final long[] results = new long[iterations];
+
+        for (int i = 0; i < iterations; i++) {
+            final BarrierTimer timer = new BarrierTimer();
+            final CyclicBarrier barrier = new CyclicBarrier(2, timer);
+            final AtomicInteger putSum = new AtomicInteger(0);
+            final AtomicInteger takeSum = new AtomicInteger(0);
+
+            Thread producer = new Thread(() -> {
+                try {
+                    int seed = (this.hashCode() ^ (int)System.nanoTime());
+                    int sum = 0;
+                    for (int j = 0; j < messageCount; j++) {
+                        logger.getMessageQueue().put(seed);
+                        sum += seed;
+                        seed ^= (seed << 3);
+                        seed ^= (seed >>> 13);
+                        seed ^= (seed << 11);
+                    }
+                    putSum.getAndAdd(sum);
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Thread consumer = new Thread(() -> {
+                try {
+                    int sum = 0;
+                    for (int j = 0; j < messageCount; j++) {
+                        sum += (int) logger.getMessageQueue().take();
+                    }
+                    takeSum.getAndAdd(sum);
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            try {
+                producer.start();
+                consumer.start();
+                barrier.await();
+                barrier.await();
+                results[i] = timer.getTime() / (2 * messageCount);
+                producer.join();
+                consumer.join();
+                expect(producer.isAlive()).toBeFalse();
+                expect(consumer.isAlive()).toBeFalse();
+                expect(putSum.get()).toEqual(takeSum.get());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        long nsPerItem = 0;
+        for (long result: results) {
+            nsPerItem += result;
+        }
+        nsPerItem /= iterations;
+
+        long stDev = 0;
+        for (long result: results) {
+            stDev += (long) Math.pow((result- nsPerItem), 2);
+        }
+        stDev /= iterations;
+        stDev = (long) Math.sqrt(stDev);
+
+        System.out.printf("Throughput: %d ns/item (SD = %d)%n", nsPerItem, stDev);
+    }
+}
+
+class BarrierTimer implements Runnable {
+    private boolean started;
+    private long startTime, endTime;
+    public synchronized void run() {
+        long t = System.nanoTime();
+        if (!started) {
+            started = true;
+            startTime = t;
+        } else
+            endTime = t;
+    }
+    public synchronized void clear() {
+        started = false;
+    }
+    public synchronized long getTime() {
+        return endTime - startTime;
+    }
+}
+
+class LinkedBaseLogger extends BaseLogger<LinkedBaseLogger> {
+
+    /**
+     * Initialize enabled logger using default url.
+     */
+    public LinkedBaseLogger() {
+        super(MOCK_AGENT);
+    }
+
+    /**
+     * Initialize enabled logger using queue.
+     */
+    public LinkedBaseLogger(List<String> queue) {
+        super(MOCK_AGENT, queue);
+    }
+
+    /**
+     * Initialize enabled logger using queue and message queue bound.
+     */
+    public LinkedBaseLogger(List<String> queue, int max_queue_depth) {
+        super(MOCK_AGENT, queue, true, max_queue_depth);
+    }
+
+    @Override
+    public void setMessageQueue(int max_queue_depth) {
+        this.msg_queue = new LinkedBlockingQueue<>(max_queue_depth);
+    }
+}

--- a/src/test/java/io/resurface/tests/ThroughputTest.java
+++ b/src/test/java/io/resurface/tests/ThroughputTest.java
@@ -28,7 +28,7 @@ public class ThroughputTest {
     }
 
     @Test
-    public void timedLinkedMessageQueueTest() throws InterruptedException{
+    public void timedLinkedMessageQueueTest() {
         for (int i = 1; i < 10000; i*=10) {
             System.out.printf("LINKED BLOCKING QUEUE (message count = %d)%n", i);
             List<String> queue = new ArrayList<>();
@@ -83,7 +83,7 @@ public class ThroughputTest {
                 consumer.start();
                 barrier.await();
                 barrier.await();
-                results[i] = timer.getTime() / (2 * messageCount);
+                results[i] = timer.getTime() / (2L * messageCount);
                 producer.join();
                 consumer.join();
                 expect(producer.isAlive()).toBeFalse();
@@ -109,52 +109,52 @@ public class ThroughputTest {
 
         System.out.printf("Throughput: %d ns/item (SD = %d)%n", nsPerItem, stDev);
     }
-}
 
-class BarrierTimer implements Runnable {
-    private boolean started;
-    private long startTime, endTime;
-    public synchronized void run() {
-        long t = System.nanoTime();
-        if (!started) {
-            started = true;
-            startTime = t;
-        } else
-            endTime = t;
-    }
-    public synchronized void clear() {
-        started = false;
-    }
-    public synchronized long getTime() {
-        return endTime - startTime;
-    }
-}
-
-class LinkedBaseLogger extends BaseLogger<LinkedBaseLogger> {
-
-    /**
-     * Initialize enabled logger using default url.
-     */
-    public LinkedBaseLogger() {
-        super(MOCK_AGENT);
+    private static class BarrierTimer implements Runnable {
+        private boolean started;
+        private long startTime, endTime;
+        public synchronized void run() {
+            long t = System.nanoTime();
+            if (!started) {
+                started = true;
+                startTime = t;
+            } else
+                endTime = t;
+        }
+        public synchronized void clear() {
+            started = false;
+        }
+        public synchronized long getTime() {
+            return endTime - startTime;
+        }
     }
 
-    /**
-     * Initialize enabled logger using queue.
-     */
-    public LinkedBaseLogger(List<String> queue) {
-        super(MOCK_AGENT, queue);
-    }
+    private static class LinkedBaseLogger extends BaseLogger<LinkedBaseLogger> {
 
-    /**
-     * Initialize enabled logger using queue and message queue bound.
-     */
-    public LinkedBaseLogger(List<String> queue, int max_queue_depth) {
-        super(MOCK_AGENT, queue, true, max_queue_depth);
-    }
+        /**
+         * Initialize enabled logger using default url.
+         */
+        public LinkedBaseLogger() {
+            super(MOCK_AGENT);
+        }
 
-    @Override
-    public void setMessageQueue(int max_queue_depth) {
-        this.msg_queue = new LinkedBlockingQueue<>(max_queue_depth);
+        /**
+         * Initialize enabled logger using queue.
+         */
+        public LinkedBaseLogger(List<String> queue) {
+            super(MOCK_AGENT, queue);
+        }
+
+        /**
+         * Initialize enabled logger using queue and message queue bound.
+         */
+        public LinkedBaseLogger(List<String> queue, int max_queue_depth) {
+            super(MOCK_AGENT, queue, true, max_queue_depth);
+        }
+
+        @Override
+        public void setMessageQueue(int max_queue_depth) {
+            this.msg_queue = new LinkedBlockingQueue<>(max_queue_depth);
+        }
     }
 }


### PR DESCRIPTION
This PR closes #62

- Add dispatcher runnable object, bounded blocking queue, and background worker thread.
- Introduce `max_queue_depth`, and `batchSize` fields as well as `stop_dispatcher` method for `BaseLogger`.
- Dispatcher is in charge of constructing and submitting NDJSON batches in a single background thread. It acts as a consumer to the message bounded queue with a max capacity given by `max_queue_depth`. Messages are produced and put in the queue using the `BaseLogger.submit` method in the calling thread. This blocks only when the batching threshold is reached, at which point the batch is flushed and sent to the `BaseLogger.url` location.
- Unit tests are updated accordingly.

In addition, this PR
- Adds missing methods from Servlet request and response implementations.
- Removes the query string from the request url when building a message (In the DB, params should only appear in `request_params`. When they show up in `request_url` a unique path is created. This is an unwanted behavior as equal paths with different qs should still be grouped together).