### PR TITLE
feat(HttpLogger): add support for v3 custom fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.resurface</groupId>
     <artifactId>resurfaceio-logger</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <name>resurfaceio-logger</name>
     <description>Library for usage logging</description>
     <url>https://github.com/resurfaceio/logger-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.resurface</groupId>
     <artifactId>resurfaceio-logger</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>resurfaceio-logger</name>
     <description>Library for usage logging</description>
     <url>https://github.com/resurfaceio/logger-java</url>

--- a/src/main/java/io/resurface/HttpLogger.java
+++ b/src/main/java/io/resurface/HttpLogger.java
@@ -2,6 +2,7 @@
 
 package io.resurface;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -120,10 +121,14 @@ public class HttpLogger extends BaseLogger<HttpLogger> {
     /**
      * Apply logging rules to message details and submit JSON message.
      */
-    public void submitIfPassing(List<String[]> details) {
+    public void submitIfPassing(List<String[]> details, HashMap<String, String> customFields) {
         // apply active rules
         details = rules.apply(details);
         if (details == null) return;
+
+        for (String field: customFields.keySet()) {
+            details.add(new String[]{field, customFields.get(field)});
+        }
 
         // finalize message
         details.add(new String[]{"host", this.host});

--- a/src/main/java/io/resurface/HttpLogger.java
+++ b/src/main/java/io/resurface/HttpLogger.java
@@ -127,7 +127,7 @@ public class HttpLogger extends BaseLogger<HttpLogger> {
         if (details == null) return;
 
         for (String field: customFields.keySet()) {
-            details.add(new String[]{field, customFields.get(field)});
+            details.add(new String[]{"custom_field:" + field, customFields.get(field)});
         }
 
         // finalize message

--- a/src/main/java/io/resurface/HttpLoggerForJersey.java
+++ b/src/main/java/io/resurface/HttpLoggerForJersey.java
@@ -139,7 +139,7 @@ public class HttpLoggerForJersey implements ContainerRequestFilter, ContainerRes
             message.add(new String[]{"now", String.valueOf(System.currentTimeMillis())});
             double interval = (System.nanoTime() - (Long) context.getProperty("resurfaceio.start")) / 1000000.0;
             message.add(new String[]{"interval", String.valueOf(interval)});
-            logger.submitIfPassing(message);
+            logger.submitIfPassing(message, null);
         } else {
             context.proceed();
         }

--- a/src/main/java/io/resurface/HttpMessage.java
+++ b/src/main/java/io/resurface/HttpMessage.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
+import java.util.HashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -20,14 +21,14 @@ public class HttpMessage {
      * Submits request and response through logger.
      */
     public static void send(HttpLogger logger, HttpServletRequest request, HttpServletResponse response) {
-        send(logger, request, response, null, null, 0, 0);
+        send(logger, request, response, null, null, 0, 0, null);
     }
 
     /**
      * Submits request and response through logger.
      */
     public static void send(HttpLogger logger, HttpServletRequest request, HttpServletResponse response, String response_body) {
-        send(logger, request, response, response_body, null, 0, 0);
+        send(logger, request, response, response_body, null, 0, 0, null);
     }
 
     /**
@@ -35,7 +36,7 @@ public class HttpMessage {
      */
     public static void send(HttpLogger logger, HttpServletRequest request, HttpServletResponse response,
                             String response_body, String request_body) {
-        send(logger, request, response, response_body, request_body, 0, 0);
+        send(logger, request, response, response_body, request_body, 0, 0, null);
     }
 
     /**
@@ -43,6 +44,15 @@ public class HttpMessage {
      */
     public static void send(HttpLogger logger, HttpServletRequest request, HttpServletResponse response,
                             String response_body, String request_body, long now, double interval) {
+        send(logger, request, response, response_body, request_body, now, interval, null);
+    }
+
+    /**
+     * Submits request and response through logger.
+     */
+    public static void send(HttpLogger logger, HttpServletRequest request, HttpServletResponse response,
+                            String response_body, String request_body, long now, double interval,
+                            HashMap<String, String> customFields) {
 
         if (!logger.isEnabled()) return;
 
@@ -71,7 +81,7 @@ public class HttpMessage {
         message.add(new String[]{"now", String.valueOf(now)});
         if (interval != 0) message.add(new String[]{"interval", String.valueOf(interval)});
 
-        logger.submitIfPassing(message);
+        logger.submitIfPassing(message, customFields);
     }
 
     /**


### PR DESCRIPTION
This PR adds support for custom fields as an enhancement of the available logger API. This feature allows the adding implementation-specific fields to the captured API calls for subsequent use once in a Resurface DB. Depending on the environment (e.g. API Gateways) these could be additional details about the API calls, like an API ID, user, tenant, subscription ID, etc.